### PR TITLE
add support for GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "It’s an extension for Gnome-Shell. It works as a reading guide for computer and this is really useful for people affected by dyslexia. It works great in helping children focusing to read very well, it marks the sentence that they are reading and hides the previous and the next one. It's already used in education projects at schools, it puts the attention on screen but it's also really useful for programmers and graphic designers who want to check their works.",
   "gettext-domain": "reading-strip",
   "settings-schema": "org.gnome.shell.extensions.readingstrip",
-  "shell-version": ["3.36", "3.38", "40", "41", "42", "43"],
+  "shell-version": ["3.36", "3.38", "40", "41", "42", "43", "44"],
   "url": "https://github.com/lupantano/readingstrip",
   "uuid": "readingstrip@lupantano.gihthub",
   "version": 25


### PR DESCRIPTION
I've added the "44" tag to the `metadata.json` file and the extension now works on GNOME 44!

![image](https://user-images.githubusercontent.com/65264536/234265985-521d3b20-c5ba-4806-bd67-94fa60d2a960.png)

Thanks for developing Reading Strip 🚀 