### PR TITLE
Fix bugs when loading and disabling the extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -216,6 +216,11 @@ class ReadingStrip {
 	    this._indicator = null;
         }
 
+	strip_h.visible = false;
+	strip_v.visible = false;
+	focus_up.visible = false;
+	focus_down.visible = false;
+
 	Main.wm.removeKeybinding('hotkey');
 	Main.wm.removeKeybinding('hotkey-locked');
 	setting_changed_signal_ids.forEach(id => settings.disconnect(id));

--- a/extension.js
+++ b/extension.js
@@ -95,6 +95,25 @@ class ReadingStrip {
 	}
     }
 
+    onSettingsChanged() {
+	strip_h.style = 'background-color : ' + settings.get_string('color-strip') + ';border: 1px solid #708090;';
+	strip_h.opacity = settings.get_double('opacity') * 255/100;
+	strip_h.height = settings.get_double('height') * Main.layoutManager.currentMonitor.height/100;
+
+	strip_v.visible = strip_h.visible && settings.get_boolean('vertical');
+	strip_v.style = strip_h.style;
+	strip_v.opacity = strip_h.opacity;
+	strip_v.width = strip_h.height / 4;
+
+	focus_up.visible = strip_h.visible && settings.get_boolean('focusmode');
+	focus_up.style = 'background-color : ' + settings.get_string('color-focus');
+
+	focus_down.visible = strip_h.visible && settings.get_boolean('focusmode');
+	focus_down.style = 'background-color : ' + settings.get_string('color-focus');
+
+	refresh = settings.get_int('refresh');
+    }
+
     enable() {
 	this.icon_on = Gio.icon_new_for_string(`${Me.path}/icons/readingstrip-on-symbolic.svg`);
 	this.icon_off = Gio.icon_new_for_string(`${Me.path}/icons/readingstrip-off-symbolic.svg`);
@@ -169,28 +188,13 @@ class ReadingStrip {
 	Main.uiGroup.add_child(focus_down);
 
 	// synchronize extension state with current settings
-	setting_changed_signal_ids.push(settings.connect('changed', () => {
-	    strip_h.style = 'background-color : ' + settings.get_string('color-strip') + ';border: 1px solid #708090;';
-	    strip_h.opacity = settings.get_double('opacity') * 255/100;
-	    strip_h.height = settings.get_double('height') * Main.layoutManager.currentMonitor.height/100;
-
-	    strip_v.visible = strip_h.visible && settings.get_boolean('vertical');
-	    strip_v.style = strip_h.style;
-	    strip_v.opacity = strip_h.opacity;
-	    strip_v.width = strip_h.height / 4;
-
-	    focus_up.visible = strip_h.visible && settings.get_boolean('focusmode');
-	    focus_up.style = 'background-color : ' + settings.get_string('color-focus');
-
-	    focus_down.visible = strip_h.visible && settings.get_boolean('focusmode');
-	    focus_down.style = 'background-color : ' + settings.get_string('color-focus');
-
-	    refresh = settings.get_int('refresh');
-	}));
+	setting_changed_signal_ids.push(settings.connect('changed', this.onSettingsChanged));
 
 	// load previous state
-	if (settings.get_boolean('enabled'))
+	if (settings.get_boolean('enabled')) {
 	    this.toggleStrip();
+	    this.onSettingsChanged();
+	}
 
 	// synchronize hot key enable/disable
 	Main.wm.addKeybinding('hotkey', settings,

--- a/extension.js
+++ b/extension.js
@@ -38,7 +38,7 @@ class ReadingStrip {
     // follow cursor position, and monitor as well
     syncStrip() {
 	const [x, y] = global.get_pointer();
-	currentMonitor = Main.layoutManager.currentMonitor;
+	const currentMonitor = Main.layoutManager.currentMonitor;
 
 	strip_h.x = currentMonitor.x;
 	strip_h.y = y - strip_h.height / 2;


### PR DESCRIPTION
Fixed 3 bugs in the extension code:
- The `currentMonitor` variable wasn't initialized properly in the newest version of Reading Strip, which would prevent the strip from displaying and cause the extension to crash.
- The reading strip would previously still stay visible if the extension was disabled. Re-enabling the extension would freeze the first reading strip in its last location and show another new reading strip, which is incorrect behaviour.
- The reading strip wouldn't immediately display again when the extension is re-enabled/after logging in again. The user would need to toggle it off and on again for the strip to appear. In other words, if the user set the `enabled` Gsetting before disabling the extension or logging back into a new session, the  wouldn't respect this Gsetting.

If you have any questions about these commits, please let me know and I would be happy to explain the pull request further.